### PR TITLE
Fix for menu not working properly in Edge

### DIFF
--- a/css/demo.css
+++ b/css/demo.css
@@ -417,11 +417,8 @@ a:focus {
 }
 
 .menu__inner {
-	position: absolute;
-	top: 0;
-	left: 0;
 	width: 100%;
-	height: 100%;
+	height: 100vh;
 	list-style-type: none;
 	padding: 20vh 3em;
 	margin: 0;

--- a/css/revealer.css
+++ b/css/revealer.css
@@ -1,3 +1,8 @@
+.block-revealer__content {
+  	transform: scale(1);
+	-webkite-transform: scale(1);
+}
+
 .block-revealer__element {
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
I gave the revealer content a scale property in order for it to form a new stacking context in Edge, and this also required a slight change in the menu to keep it in view.